### PR TITLE
fix for tooltip not opening after author modal window is closed

### DIFF
--- a/sites/all/modules/weill/citations/js/citations.js
+++ b/sites/all/modules/weill/citations/js/citations.js
@@ -69,6 +69,11 @@ jQuery(document).on('mouseover', '.qtip-citation-author', function() {
         },
         hide: {
             event: 'unfocus'
+        },
+        events: {
+            hide: function(event, api) {
+                jQuery('#qtip-overlay').remove();
+            }
         }
     });
 });


### PR DESCRIPTION
When the modal is enabled, it adds a div for the dark overlay, but when its closed, it doesn’t remove it from the DOM, that seems to clash with the tooltip
the dark overlay div, its not removed from the page when closed, so added a callback function the author modal is closed to remove it